### PR TITLE
chore: enforce issue-linked PR descriptions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Summary
+- What changed and why:
+
+## Linked Issue
+Closes #<issue-number>
+
+## Validation
+- [ ] `flutter analyze` passes
+- [ ] `flutter test` passes
+
+## Checklist
+- [ ] Scope is limited to a single issue
+- [ ] Tests were added or updated where needed
+- [ ] Documentation was updated where relevant

--- a/.github/workflows/pr-issue-link-check.yml
+++ b/.github/workflows/pr-issue-link-check.yml
@@ -1,0 +1,28 @@
+name: PR Issue Link Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  require-linked-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR body contains closing keyword
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = (context.payload.pull_request.body || '');
+            const re = /\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#\d+\b/i;
+
+            if (!re.test(body)) {
+              core.setFailed(
+                'PR body must include a linked closing reference, e.g. "Closes #7".'
+              );
+              return;
+            }
+
+            core.info('PR includes a valid closing issue reference.');


### PR DESCRIPTION
## Summary\n- add a default PR template requiring a linked issue line\n- add CI workflow to fail PRs without a closing issue reference (e.g. Closes #7)\n\n## Why\n- keeps one-issue-per-PR workflow traceable\n- ensures issue closure is automated on merge\n\n## Validation\n- workflow YAML checked in editor diagnostics\n\nCloses #6