### PR TITLE
[#92] Persist imported sessions in Sessions screen

### DIFF
--- a/lib/app_shell.dart
+++ b/lib/app_shell.dart
@@ -3,6 +3,8 @@ import 'dart:convert';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 
+import 'models/session_metadata.dart';
+import 'repositories/session_repository.dart';
 import 'screens/analysis_screen.dart';
 import 'screens/comparison_screen.dart';
 import 'screens/import_screen.dart';
@@ -77,6 +79,7 @@ class AppShell extends StatefulWidget {
 
 class _AppShellState extends State<AppShell> {
   int _selectedIndex = 0;
+  final SessionRepository _sessionRepository = SessionRepository();
 
   /// Picks a file using the platform file picker and returns a [FileSelection]
   /// containing the file name and decoded text content, or `null` if the user
@@ -117,13 +120,20 @@ class _AppShellState extends State<AppShell> {
           onPickFrontFile: _pickFile,
           onPickRearFile: _pickFile,
           onNavigateToSessions: () => _onDestinationSelected(1),
+          onImportCompleted: _onImportCompleted,
         ),
-        const SessionsScreen(),
+        SessionsScreen(repository: _sessionRepository),
         const AnalysisScreen(),
         const TuningScreen(),
         const ComparisonScreen(),
         const SettingsScreen(),
       ];
+
+  void _onImportCompleted(List<SessionMetadata> sessions) {
+    for (final session in sessions) {
+      _sessionRepository.add(session);
+    }
+  }
 
   void _onDestinationSelected(int index) {
     setState(() => _selectedIndex = index);

--- a/lib/screens/import_screen.dart
+++ b/lib/screens/import_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../models/imu_sample.dart';
 import '../models/session_metadata.dart';
 import '../models/validation_report.dart';
 import '../services/data_import/import_service.dart';
@@ -7,6 +8,9 @@ import '../services/data_import/import_service.dart';
 /// Callback for picking a file; returns [FileSelection] on success,
 /// or `null` when the user cancels.
 typedef PickFileCallback = Future<FileSelection?> Function();
+
+/// Callback invoked after a successful import with created session metadata.
+typedef ImportCompletedCallback = void Function(List<SessionMetadata> sessions);
 
 /// File import screen with front/rear sensor file selection,
 /// import-progress tracking, cancellation support, and a validation summary.
@@ -27,6 +31,7 @@ class ImportScreen extends StatefulWidget {
     this.onPickRearFile,
     this.service,
     this.onNavigateToSessions,
+    this.onImportCompleted,
   });
 
   /// Invoked when the user taps "Select" for the front sensor file.
@@ -42,6 +47,10 @@ class ImportScreen extends StatefulWidget {
   /// Called when the user taps "Go to Sessions" after a successful import.
   /// When omitted the button is shown in a disabled state.
   final VoidCallback? onNavigateToSessions;
+
+  /// Called when import finishes successfully with one or more imported
+  /// session metadata entries.
+  final ImportCompletedCallback? onImportCompleted;
 
   @override
   State<ImportScreen> createState() => _ImportScreenState();
@@ -135,9 +144,84 @@ class _ImportScreenState extends State<ImportScreen> {
       if (_rearFile != null && !_cancelled && _errorMessage == null) {
         await _runImport(_rearFile!, SensorPosition.rear, gen);
       }
+
+      // Persist imported metadata only when the run completed successfully.
+      if (!_cancelled && _errorMessage == null) {
+        final imported = _buildImportedSessions();
+        if (imported.isNotEmpty) {
+          widget.onImportCompleted?.call(imported);
+        }
+      }
     } finally {
       if (mounted && _generation == gen) setState(() => _importing = false);
     }
+  }
+
+  List<SessionMetadata> _buildImportedSessions() {
+    final now = DateTime.now().toUtc();
+    final baseId = now.toIso8601String();
+    final hasFront = _frontResult != null;
+    final hasRear = _rearResult != null;
+    final both = hasFront && hasRear;
+
+    String idFor(SensorPosition p) {
+      if (!both) return baseId;
+      return '$baseId-${p.name}';
+    }
+
+    String? pairFor(SensorPosition p) {
+      if (!both) return null;
+      final other = p == SensorPosition.front
+          ? SensorPosition.rear
+          : SensorPosition.front;
+      return idFor(other);
+    }
+
+    final sessions = <SessionMetadata>[];
+    if (_frontResult != null) {
+      sessions.add(
+        SessionMetadata(
+          sessionId: idFor(SensorPosition.front),
+          position: SensorPosition.front,
+          recordedAt: now,
+          samplingRateHz: _estimateSamplingRateHz(_frontResult!.samples),
+          pairedSessionId: pairFor(SensorPosition.front),
+        ),
+      );
+    }
+    if (_rearResult != null) {
+      sessions.add(
+        SessionMetadata(
+          sessionId: idFor(SensorPosition.rear),
+          position: SensorPosition.rear,
+          recordedAt: now,
+          samplingRateHz: _estimateSamplingRateHz(_rearResult!.samples),
+          pairedSessionId: pairFor(SensorPosition.rear),
+        ),
+      );
+    }
+    return sessions;
+  }
+
+  double _estimateSamplingRateHz(List<ImuSample> samples) {
+    if (samples.length < 2) return 200.0;
+
+    int totalDeltaMs = 0;
+    int count = 0;
+    for (int i = 1; i < samples.length; i++) {
+      final prev = samples[i - 1];
+      final curr = samples[i];
+      final dt = curr.timestampMs - prev.timestampMs;
+      if (dt > 0) {
+        totalDeltaMs += dt;
+        count++;
+      }
+    }
+
+    if (count == 0) return 200.0;
+    final avgDeltaMs = totalDeltaMs / count;
+    final hz = 1000.0 / avgDeltaMs;
+    return hz.isFinite && hz > 0 ? hz : 200.0;
   }
 
   Future<void> _runImport(

--- a/test/widget/import_screen_test.dart
+++ b/test/widget/import_screen_test.dart
@@ -458,6 +458,36 @@ void main() {
       expect(navigateCalled, isTrue);
     });
 
+    testWidgets('successful import invokes onImportCompleted callback',
+        (tester) async {
+      final imported = <SessionMetadata>[];
+
+      await tester.pumpWidget(
+        _wrap(
+          ImportScreen(
+            onPickFrontFile: () => _pick(_frontSelection),
+            onImportCompleted: (sessions) => imported.addAll(sessions),
+          ),
+        ),
+      );
+
+      await tester.tap(
+        find.descendant(
+          of: find.widgetWithText(Card, 'Front Sensor'),
+          matching: find.text('Select'),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('import_button')));
+      await tester.pumpAndSettle();
+
+      expect(imported, hasLength(1));
+      expect(imported.first.position, SensorPosition.front);
+      expect(imported.first.sessionId, isNotEmpty);
+      expect(imported.first.recordedAt, isNotNull);
+    });
+
     testWidgets('Go to Sessions button not shown before import completes',
         (tester) async {
       final ctrl = StreamController<ImportState>();


### PR DESCRIPTION
## Summary
- wire `ImportScreen` to emit imported `SessionMetadata` via `onImportCompleted`
- persist emitted metadata into an app-scoped `SessionRepository` in `AppShell`
- pass the shared repository into `SessionsScreen` so newly imported sessions appear immediately
- add widget regression coverage for import completion callback behavior

## Why
After importing CSV files, navigating to Sessions still showed the empty state ("Import data to create a session") because import results were not being written to the repository used by `SessionsScreen`.

Closes #92

## Validation
- Attempted: `flutter analyze` (blocked: `flutter: command not found` in this dev container)
- Attempted: `flutter test test/widget/import_screen_test.dart test/sessions_screen_test.dart test/app_shell_test.dart` (blocked: `flutter: command not found`)
- Editor diagnostics: no errors in changed files (`lib/app_shell.dart`, `lib/screens/import_screen.dart`, `test/widget/import_screen_test.dart`)
