### PR TITLE
[#97] Add dedicated 3D Visualization tab

### DIFF
--- a/lib/app_shell.dart
+++ b/lib/app_shell.dart
@@ -11,6 +11,7 @@ import 'screens/import_screen.dart';
 import 'screens/sessions_screen.dart';
 import 'screens/settings_screen.dart';
 import 'screens/tuning_screen.dart';
+import 'screens/visualization_screen.dart';
 import 'services/data_import/decompressor.dart';
 import 'services/data_import/import_service.dart';
 
@@ -46,6 +47,11 @@ const List<_NavDestination> _destinations = [
     label: 'Analysis',
     icon: Icon(Icons.show_chart_outlined),
     selectedIcon: Icon(Icons.show_chart),
+  ),
+  _NavDestination(
+    label: '3D View',
+    icon: Icon(Icons.view_in_ar_outlined),
+    selectedIcon: Icon(Icons.view_in_ar),
   ),
   _NavDestination(
     label: 'Tuning',
@@ -124,6 +130,7 @@ class _AppShellState extends State<AppShell> {
         ),
         SessionsScreen(repository: _sessionRepository),
         const AnalysisScreen(),
+        const VisualizationScreen(),
         const TuningScreen(),
         const ComparisonScreen(),
         const SettingsScreen(),

--- a/lib/screens/visualization_screen.dart
+++ b/lib/screens/visualization_screen.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+
+import '../models/suspension_state.dart';
+import '../widgets/suspension_scene_widget.dart';
+
+/// Dedicated visualization screen displaying the 3D suspension scene
+/// (FR-UI-004, FR-VZ-002).
+///
+/// Shows the animated motorcycle suspension model with camera controls.
+/// Future enhancements can add camera mode toggles, playback controls,
+/// and session data integration.
+class VisualizationScreen extends StatefulWidget {
+  const VisualizationScreen({super.key, this.state});
+
+  /// Optional suspension state override for testing.
+  /// When omitted, displays a demo animation with periodic compression/extension.
+  final SuspensionState? state;
+
+  @override
+  State<VisualizationScreen> createState() => _VisualizationScreenState();
+}
+
+class _VisualizationScreenState extends State<VisualizationScreen>
+    with SingleTickerProviderStateMixin {
+  late AnimationController _demoController;
+  late Animation<double> _travelAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+    _demoController = AnimationController(
+      vsync: this,
+      duration: const Duration(seconds: 3),
+    )..repeat(reverse: true);
+
+    _travelAnimation = Tween<double>(begin: 0.0, end: 80.0).animate(
+      CurvedAnimation(parent: _demoController, curve: Curves.easeInOut),
+    );
+  }
+
+  @override
+  void dispose() {
+    _demoController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _buildInfoBanner(context),
+        Expanded(
+          child: AnimatedBuilder(
+            animation: _travelAnimation,
+            builder: (context, _) {
+              final state = widget.state ??
+                  SuspensionState(
+                    frontTravelMm: _travelAnimation.value,
+                    rearTravelMm: _travelAnimation.value * 0.8,
+                  );
+              return SuspensionSceneWidget(state: state);
+            },
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildInfoBanner(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      decoration: BoxDecoration(
+        color: colorScheme.surfaceContainerHighest,
+        border: Border(
+          bottom: BorderSide(color: colorScheme.outlineVariant),
+        ),
+      ),
+      child: Row(
+        children: [
+          Icon(Icons.view_in_ar, size: 20, color: colorScheme.primary),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              'Interactive 3D suspension model',
+              style: textTheme.titleSmall?.copyWith(
+                color: colorScheme.onSurface,
+              ),
+            ),
+          ),
+          Text(
+            'Demo mode - session integration pending',
+            style: textTheme.bodySmall?.copyWith(
+              color: colorScheme.outline,
+              fontStyle: FontStyle.italic,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/widget/visualization_screen_test.dart
+++ b/test/widget/visualization_screen_test.dart
@@ -1,0 +1,81 @@
+// Widget tests for VisualizationScreen.
+//
+// Covers:
+//   - Screen renders without errors
+//   - Info banner displays correctly
+//   - SuspensionSceneWidget is present
+//   - Demo animation runs
+//   - Custom state can be injected
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:ride_metric_x/models/suspension_state.dart';
+import 'package:ride_metric_x/screens/visualization_screen.dart';
+import 'package:ride_metric_x/widgets/suspension_scene_widget.dart';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+Widget _wrap(Widget screen) => MaterialApp(home: Scaffold(body: screen));
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+void main() {
+  group('VisualizationScreen', () {
+    testWidgets('renders without errors', (tester) async {
+      await tester.pumpWidget(_wrap(const VisualizationScreen()));
+      expect(find.byType(VisualizationScreen), findsOneWidget);
+    });
+
+    testWidgets('displays info banner', (tester) async {
+      await tester.pumpWidget(_wrap(const VisualizationScreen()));
+      expect(find.text('Interactive 3D suspension model'), findsOneWidget);
+      expect(
+        find.text('Demo mode - session integration pending'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('contains SuspensionSceneWidget', (tester) async {
+      await tester.pumpWidget(_wrap(const VisualizationScreen()));
+      expect(find.byType(SuspensionSceneWidget), findsOneWidget);
+    });
+
+    testWidgets('accepts custom suspension state', (tester) async {
+      const customState = SuspensionState(
+        frontTravelMm: 50.0,
+        rearTravelMm: 40.0,
+      );
+
+      await tester.pumpWidget(
+        _wrap(const VisualizationScreen(state: customState)),
+      );
+
+      expect(find.byType(SuspensionSceneWidget), findsOneWidget);
+    });
+
+    testWidgets('demo animation updates suspension state', (tester) async {
+      await tester.pumpWidget(_wrap(const VisualizationScreen()));
+
+      // Initial frame
+      await tester.pump();
+
+      // Advance animation
+      await tester.pump(const Duration(milliseconds: 500));
+
+      // Scene widget should still be present and animating
+      expect(find.byType(SuspensionSceneWidget), findsOneWidget);
+    });
+
+    testWidgets('displays 3D icon in banner', (tester) async {
+      await tester.pumpWidget(_wrap(const VisualizationScreen()));
+
+      expect(
+        find.byWidgetPredicate(
+          (w) => w is Icon && w.icon == Icons.view_in_ar,
+        ),
+        findsOneWidget,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Adds a dedicated "3D View" navigation tab that displays the fully-implemented `SuspensionSceneWidget` with an animated 3D motorcycle suspension model.

## Changes
- **New screen**: `lib/screens/visualization_screen.dart`
  - Wraps `SuspensionSceneWidget` with info banner
  - Includes demo animation controller that cycles suspension travel
  - Ready for future session data integration
- **AppShell navigation**: Added "3D View" destination between Analysis and Tuning
  - Icon: `view_in_ar` (Material 3D icon)
  - Position: 4th tab (Import → Sessions → Analysis → **3D View** → Tuning → Compare → Settings)
- **Test coverage**: `test/widget/visualization_screen_test.dart`
  - Verifies screen renders without errors
  - Tests info banner content
  - Validates `SuspensionSceneWidget` integration
  - Confirms custom state injection support

## Why
The 3D suspension visualization infrastructure was fully implemented but never exposed in any screen. Users had no way to see the 3D model.

Closes #97

## Screenshots / Demo
The new tab displays:
- Animated 3D suspension scene (60 fps by default)
- Info banner: "Interactive 3D suspension model"
- Status label: "Demo mode - session integration pending"

Future enhancements will connect it to real session data and add camera controls.

## Validation
- Editor diagnostics: no errors
- All files committed cleanly
- Tests included for new screen
- `flutter test` blocked (flutter command unavailable in container), will run in CI
